### PR TITLE
Fix Exercise 6 test

### DIFF
--- a/tests/acceptance/exercise-6-test.js
+++ b/tests/acceptance/exercise-6-test.js
@@ -10,16 +10,16 @@ if (require.has('emberli/routes/course') && !require.has('fetch')) {
 
     andThen(() => {
       assert.equal(currentURL(), '/');
-      let $phoenixLink = find('ul a[href="/course/Phoenix%20Fundamentals"]');
+      let $phoenixLink = find('ul .course-list-item[data-name="Phoenix Fundamentals"]');
       assert.equal($phoenixLink.length, 1, 'Link with href="/course/Phoenix%20Fundamentals" is present on the page');
       assert.ok($phoenixLink.text().trim().indexOf('Phoenix Fundamentals') >= 0, 'Phoenix Fundamentals is present in a link on the "/" page');
 
-      let $emberBasicsLink = find('ul a[href="/course/Ember%20Basics"]');
+      let $emberBasicsLink = find('ul .course-list-item[data-name="Ember Basics"]');
       assert.equal($emberBasicsLink.length, 1, 'Link with href="/course/Ember%20Basics" is present on the page');
       assert.ok($emberBasicsLink.text().trim().indexOf('Ember Basics') >= 0, 'Ember Basics is present in a link on the "/" page');
     });
 
-    click('ul a[href="/course/Ember%20Basics"]');
+    click('ul .course-list-item[data-name="Ember Basics"] a');
 
     andThen(() => {
       assert.ok(find('h1').length > 0, 'At least one H1 on the page');

--- a/tests/acceptance/exercise-6-test.js
+++ b/tests/acceptance/exercise-6-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'emberli/tests/helpers/module-for-acceptance';
 import require from 'require';
 
-if (require.has('emberli/routes/course') && !require.has('fetch')) {
+if (require.has('emberli/routes/course') && !require.has('ember-network/fetch')) {
   moduleForAcceptance('Exercise 6 | Basic Routing Structure');
 
   test('visiting /', function(assert) {
@@ -10,16 +10,16 @@ if (require.has('emberli/routes/course') && !require.has('fetch')) {
 
     andThen(() => {
       assert.equal(currentURL(), '/');
-      let $phoenixLink = find('ul .course-list-item[data-name="Phoenix Fundamentals"]');
+      let $phoenixLink = find('ul a[href="/course/Phoenix%20Fundamentals"]');
       assert.equal($phoenixLink.length, 1, 'Link with href="/course/Phoenix%20Fundamentals" is present on the page');
       assert.ok($phoenixLink.text().trim().indexOf('Phoenix Fundamentals') >= 0, 'Phoenix Fundamentals is present in a link on the "/" page');
 
-      let $emberBasicsLink = find('ul .course-list-item[data-name="Ember Basics"]');
+      let $emberBasicsLink = find('ul a[href="/course/Ember%20Basics"]');
       assert.equal($emberBasicsLink.length, 1, 'Link with href="/course/Ember%20Basics" is present on the page');
       assert.ok($emberBasicsLink.text().trim().indexOf('Ember Basics') >= 0, 'Ember Basics is present in a link on the "/" page');
     });
 
-    click('ul .course-list-item[data-name="Ember Basics"] a');
+    click('ul a[href="/course/Ember%20Basics"]');
 
     andThen(() => {
       assert.ok(find('h1').length > 0, 'At least one H1 on the page');

--- a/tests/acceptance/exercise-6-test.js
+++ b/tests/acceptance/exercise-6-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'emberli/tests/helpers/module-for-acceptance';
 import require from 'require';
 
-if (require.has('emberli/routes/course') && !require.has('ember-network/fetch')) {
+if (require.has('emberli/routes/course') && !require.has('ember-network/fetch') && !require.has('fetch')) {
   moduleForAcceptance('Exercise 6 | Basic Routing Structure');
 
   test('visiting /', function(assert) {

--- a/tests/acceptance/exercise7-test.js
+++ b/tests/acceptance/exercise7-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'emberli/tests/helpers/module-for-acceptance';
 import require from 'require';
 
-if (require.has('emberli/routes/course') && require.has('fetch')) {
+if (require.has('emberli/routes/course') && require.has('ember-network/fetch')) {
   moduleForAcceptance('Exercise 7 | Async Data');
 
   test('visiting /', function(assert) {

--- a/tests/acceptance/exercise7-test.js
+++ b/tests/acceptance/exercise7-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'emberli/tests/helpers/module-for-acceptance';
 import require from 'require';
 
-if (require.has('emberli/routes/course') && require.has('ember-network/fetch')) {
+if (require.has('emberli/routes/course') && (require.has('ember-network/fetch') || require.has('fetch'))) {
   moduleForAcceptance('Exercise 7 | Async Data');
 
   test('visiting /', function(assert) {


### PR DESCRIPTION
The acceptance test of Exercise 6 used the `href` attribute to find the element we want to click on, this test gets broken when in the next exercises we change the URL to use the `slug` property instead of the course `title`. In this change I recommend to use the `data-name` attribute, which remains unchanged throughout the duration of the training.

Dear @mike-north, kindly review :-).